### PR TITLE
総合結果画面からトップ画面へ遷移できる

### DIFF
--- a/angular-app/src/app/app-routing.module.ts
+++ b/angular-app/src/app/app-routing.module.ts
@@ -4,12 +4,14 @@ import { InfoComponent } from './info/info.component';
 import { QuizPageComponent } from './quiz-page/quiz-page.component';
 import { TopComponent } from './top/top.component';
 import { JudgmentComponent } from './judgment/judgment.component';
+import { ResultComponent } from './result/result.component';
 
 const routes: Routes = [
   {path: '', component: TopComponent},
   {path: 'info', component: InfoComponent},
   {path: 'quiz', component: QuizPageComponent},
-  {path: 'judge', component: JudgmentComponent}
+  {path: 'judge', component: JudgmentComponent},
+  {path: 'result', component: ResultComponent}
 ];
 
 @NgModule({

--- a/angular-app/src/app/app.module.ts
+++ b/angular-app/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { InfoComponent } from './info/info.component';
 import {MatButtonModule} from '@angular/material/button';
 import { QuizPageComponent } from './quiz-page/quiz-page.component';
 import { JudgmentComponent } from './judgment/judgment.component';
+import { ResultComponent } from './result/result.component';
 
 
 @NgModule({
@@ -18,7 +19,8 @@ import { JudgmentComponent } from './judgment/judgment.component';
     TopComponent,
     InfoComponent,
     QuizPageComponent,
-    JudgmentComponent
+    JudgmentComponent,
+    ResultComponent
   ],
   imports: [
     BrowserModule,

--- a/angular-app/src/app/result/result.component.html
+++ b/angular-app/src/app/result/result.component.html
@@ -8,5 +8,5 @@
       <p>その優れた知識とともにスキーの発展に期待され、これを賞します。</p>
     </div>
   </div>
-  <button mat-fab extended class="retry">はじめに戻る</button>
+  <button mat-fab extended class="retry" routerLink="/">はじめに戻る</button>
 </div>

--- a/angular-app/src/app/result/result.component.html
+++ b/angular-app/src/app/result/result.component.html
@@ -1,0 +1,12 @@
+<div class="wrapper">
+  <div class="total-result">
+    <p>総合結果は、、、７問正解</p>
+  </div>
+  <div class="rank">
+    <div class="rank-content">
+      <p>あなたは、プロです。</p>
+      <p>その優れた知識とともにスキーの発展に期待され、これを賞します。</p>
+    </div>
+  </div>
+  <button mat-fab extended class="retry">はじめに戻る</button>
+</div>

--- a/angular-app/src/app/result/result.component.scss
+++ b/angular-app/src/app/result/result.component.scss
@@ -1,0 +1,49 @@
+.wrapper {
+  background-color: #eaf5f8;
+  height: 100%;
+  padding-top: 5%;
+
+  .total-result {
+    background-color: #f7f7f7;
+    border-radius: 5px;
+    border: 1px solid #707070;
+    text-align: center;
+    width: 80vw;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 960px;
+  }
+
+  .rank {
+    background-color: #f7f7f7;
+    border-radius: 5px;
+    border: 1px solid #707070;
+    text-align: left;
+    width: 80vw;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 960px;
+    margin-top: 1.2%;
+
+    .rank-content {
+      padding: 2% 2%;
+    }
+  }
+
+  .retry {
+    color: #707070;
+    background-color: #a6d7ed;
+    display: flex;
+    margin: 0 auto;
+    width: 24vw;
+    margin-top: 8%;
+    font-size: 2vw;
+  }
+
+  @media screen and (max-width: 600px) {
+    .retry {
+      margin-top: 300px;
+      width: 200px;
+    }
+  }
+}

--- a/angular-app/src/app/result/result.component.spec.ts
+++ b/angular-app/src/app/result/result.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ResultComponent } from './result.component';
+
+describe('ResultComponent', () => {
+  let component: ResultComponent;
+  let fixture: ComponentFixture<ResultComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ResultComponent]
+    });
+    fixture = TestBed.createComponent(ResultComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular-app/src/app/result/result.component.ts
+++ b/angular-app/src/app/result/result.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-result',
+  templateUrl: './result.component.html',
+  styleUrls: ['./result.component.scss']
+})
+export class ResultComponent {
+
+}


### PR DESCRIPTION
## Checklist for Developer

- [x] 最新のdevelopブランチをPullした。 Pulled the latest develop branch.
- [x] Pull RequestをIssueに紐付けた。 Connected with the issue.
- [x] 自分をAssignした。Assigned yourself.
- [x] レビュワーを指定した。Assigned reviewer.

## そのほかの関連するIssue / Related issues other than connected one

- #16 

## 変更内容 / Details of Changes
1. 総合結果画面から「はじめに戻る」を選択するとトップ画面へ遷移できるようにしました。

## スクリーンショット / Screenshots
### 総合結果画面から「はじめに戻る」を選択する

![スクリーンショット 2023-06-26 14 27 44](https://github.com/yousukeend/alpinea/assets/40225496/8ef8f58c-476b-4418-bd5a-fafea07ff381)

- 総合結果画面の「はじめに戻る」を選択する


### トップ画面へ遷移する


![スクリーンショット 2023-06-26 14 56 00](https://github.com/yousukeend/alpinea/assets/40225496/7e56ce15-d931-4453-8871-7c93fd21d2f3)

- `localhost:4200` へ画面が遷移する


## レビューするポイント/ Points for review
- `localhost:4200/result`にアクセスできる
- 総合結果画面の「はじめに戻る」を選択し、`localhost:4200`へ遷移できる