### PR TITLE
クイズ画面で動画を繰り返して再生できるようにしました

### DIFF
--- a/angular-app/src/app/dataContent.ts
+++ b/angular-app/src/app/dataContent.ts
@@ -1,0 +1,5 @@
+import { ImageData } from "./imgData";
+
+export const DATA: ImageData[] = [
+  {quizText: '後ろに見える山は何でしょう?', quizImg: 'https://drive.google.com/file/d/14ZKtwNlNXahxMutSJW_paBAxvvoim0qw/preview', ansOptions: ["岩手山", "蔵王山", "大雪山", "安達太良山"], ansWord: '岩手山は日本百名山に選定されており、標高2,038mの成層火山です。冬になれば綺麗な雪山を見ることができます。', ansImg: '"https://drive.google.com/file/d/14ZKtwNlNXahxMutSJW_paBAxvvoim0qw/preview"'},
+]

--- a/angular-app/src/app/dataContent.ts
+++ b/angular-app/src/app/dataContent.ts
@@ -1,5 +1,7 @@
 import { ImageData } from "./imgData";
 
 export const DATA: ImageData[] = [
-  {quizText: '後ろに見える山は何でしょう?', quizImg: 'https://drive.google.com/file/d/14ZKtwNlNXahxMutSJW_paBAxvvoim0qw/preview', ansOptions: ["岩手山", "蔵王山", "大雪山", "安達太良山"], ansWord: '岩手山は日本百名山に選定されており、標高2,038mの成層火山です。冬になれば綺麗な雪山を見ることができます。', ansImg: '"https://drive.google.com/file/d/14ZKtwNlNXahxMutSJW_paBAxvvoim0qw/preview"'},
+  {quizText: '後ろに見える山は何でしょう?', quizImg: 'https://drive.google.com/file/d/14ZKtwNlNXahxMutSJW_paBAxvvoim0qw/preview', ansOptions: ["岩手山", "蔵王山", "大雪山", "安達太良山"], ansWord: '岩手山は日本百名山に選定されており、標高2,038mの成層火山です。冬になれば綺麗な雪山を見ることができます。', ansImg: 'https://drive.google.com/file/d/14ZKtwNlNXahxMutSJW_paBAxvvoim0qw/preview'},
+  {quizText: 'この滑り方は何でしょう?', quizImg: 'https://drive.google.com/file/d/1wj34phlrTKWtEBUw21U_-9D85HA0Uyl0/preview', ansOptions: ["ショートターン", "ロングターン", "ミドルターン", "ミニマムターン"], ansWord: 'ターン幅を短くして滑るターン方法です。スキー操作を早く動かすため中級者〜上級者レベルになります。', ansImg: 'https://drive.google.com/file/d/1WKVzZ9kMdemzPCp-gdiynk7uVIb5_Bky/preview'},
+
 ]

--- a/angular-app/src/app/imgData.ts
+++ b/angular-app/src/app/imgData.ts
@@ -1,0 +1,7 @@
+export interface ImageData {
+  quizText: string;
+  quizImg: string;
+  ansOptions: string[];
+  ansWord: string;
+  ansImg: string;
+}

--- a/angular-app/src/app/info/info.component.html
+++ b/angular-app/src/app/info/info.component.html
@@ -6,5 +6,5 @@
     <p>階級は、プロ、上級者、中級者、初心者に分けられます。</p>
     <p>全問正解してプロの階級を目指せ！</p>
   </div>
-  <button mat-raised-button class="start-button">スタート</button>
+  <button mat-raised-button class="start-button" routerLink="/quiz">スタート</button>
 </div>

--- a/angular-app/src/app/quiz-page/quiz-page.component.html
+++ b/angular-app/src/app/quiz-page/quiz-page.component.html
@@ -1,20 +1,20 @@
 <div class="wrapper">
   <div class="quiz-content">
 
-    <p  class="quiz-text">問題１：{{ data[0].quizText }}</p>
+    <p  class="quiz-text">問題１：{{ data[1].quizText }}</p>
 
   </div>
   <div class="imgData-content">
     <!-- 画像テスト -->
-    <iframe class="imgData-source" [src]="trustUrl" allow="autoplay"></iframe>
+    <!-- <iframe class="imgData-source" [src]="trustUrl" allow="autoplay"></iframe> -->
     <!-- 動画テスト -->
-    <!-- <iframe class="imgData-source" src="https://drive.google.com/file/d/1SVOnvWsQjx6tsNnxLdxycPPWu-O3ClBj/preview" allow="autoplay"></iframe> -->
+    <iframe class="imgData-source" [src]="trustUrl" allow="autoplay"></iframe>
   </div>
 
   <div class="selection">
-    <button mat-flat-button class="sl-btn">{{ data[0].ansOptions[0] }}</button>
-    <button mat-flat-button class="sl-btn">{{ data[0].ansOptions[1] }}</button>
-    <button mat-flat-button class="sl-btn">{{ data[0].ansOptions[2] }}</button>
-    <button mat-flat-button class="sl-btn">{{ data[0].ansOptions[3] }}</button>
+    <button mat-flat-button class="sl-btn">{{ data[1].ansOptions[0] }}</button>
+    <button mat-flat-button class="sl-btn">{{ data[1].ansOptions[1] }}</button>
+    <button mat-flat-button class="sl-btn">{{ data[1].ansOptions[2] }}</button>
+    <button mat-flat-button class="sl-btn">{{ data[1].ansOptions[3] }}</button>
   </div>
 </div>

--- a/angular-app/src/app/quiz-page/quiz-page.component.html
+++ b/angular-app/src/app/quiz-page/quiz-page.component.html
@@ -1,15 +1,20 @@
 <div class="wrapper">
   <div class="quiz-content">
-    <p class="quiz-text">問題１：ここはどこでしょう？</p>
+
+    <p  class="quiz-text">問題１：{{ data[0].quizText }}</p>
+
   </div>
   <div class="imgData-content">
-    <p>動画・写真を挟む 比率16:9にする</p>
+    <!-- 画像テスト -->
+    <iframe class="imgData-source" [src]="trustUrl" allow="autoplay"></iframe>
+    <!-- 動画テスト -->
+    <!-- <iframe class="imgData-source" src="https://drive.google.com/file/d/1SVOnvWsQjx6tsNnxLdxycPPWu-O3ClBj/preview" allow="autoplay"></iframe> -->
   </div>
 
   <div class="selection">
-    <button mat-flat-button class="sl-btn">月山</button>
-    <button mat-flat-button class="sl-btn">安比高原</button>
-    <button mat-flat-button class="sl-btn">志賀高原</button>
-    <button mat-flat-button class="sl-btn">山形蔵王</button>
+    <button mat-flat-button class="sl-btn">{{ data[0].ansOptions[0] }}</button>
+    <button mat-flat-button class="sl-btn">{{ data[0].ansOptions[1] }}</button>
+    <button mat-flat-button class="sl-btn">{{ data[0].ansOptions[2] }}</button>
+    <button mat-flat-button class="sl-btn">{{ data[0].ansOptions[3] }}</button>
   </div>
 </div>

--- a/angular-app/src/app/quiz-page/quiz-page.component.scss
+++ b/angular-app/src/app/quiz-page/quiz-page.component.scss
@@ -25,6 +25,11 @@
     margin: 5%;
     max-width: 960px;
     margin: 0 auto;
+
+    .imgData-source {
+      width: 100%;
+      height: 100%;
+    }
   }
 
   .selection {

--- a/angular-app/src/app/quiz-page/quiz-page.component.ts
+++ b/angular-app/src/app/quiz-page/quiz-page.component.ts
@@ -1,4 +1,6 @@
 import { Component } from '@angular/core';
+import { DATA } from '../dataContent';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-quiz-page',
@@ -6,5 +8,10 @@ import { Component } from '@angular/core';
   styleUrls: ['./quiz-page.component.scss']
 })
 export class QuizPageComponent {
+  data = DATA;
+  trustUrl: SafeResourceUrl;
 
+  constructor(private sanitizer: DomSanitizer){
+    this.trustUrl = sanitizer.bypassSecurityTrustResourceUrl(this.data[0].quizImg);
+  }
 }

--- a/angular-app/src/app/quiz-page/quiz-page.component.ts
+++ b/angular-app/src/app/quiz-page/quiz-page.component.ts
@@ -12,6 +12,6 @@ export class QuizPageComponent {
   trustUrl: SafeResourceUrl;
 
   constructor(private sanitizer: DomSanitizer){
-    this.trustUrl = sanitizer.bypassSecurityTrustResourceUrl(this.data[0].quizImg);
+    this.trustUrl = sanitizer.bypassSecurityTrustResourceUrl(this.data[1].quizImg);
   }
 }


### PR DESCRIPTION
## Checklist for Developer

- [x] 最新のdevelopブランチをPullした。 Pulled the latest develop branch.
- [x] Pull RequestをIssueに紐付けた。 Connected with the issue.
- [x] 自分をAssignした。Assigned yourself.
- [x] レビュワーを指定した。Assigned reviewer.

## そのほかの関連するIssue / Related issues other than connected one

- #9 

## 変更内容 / Details of Changes
1. クイズ画面で動画の場合、繰り返して再生(iframeを使って)できるようにしました。

## スクリーンショット / Screenshots
### クイズ画面で動画が繰り返して再生できる

![スクリーンショット 2023-07-03 20 50 07](https://github.com/yousukeend/alpinea/assets/40225496/414a7bb7-e4cd-4a0a-ac33-ea0f5e79f75a)


- `localhost:4200/quiz`クイズ画面で動画が再生でき、繰り返しボタン(動画埋め込みの左下の矢印)で再生できる

## レビューするポイント/ Points for review
- `localhost:4200/quiz`クイズ画面で動画が再生と繰り返し再生できる