### PR TITLE
判定画面へ遷移したときに正解か不正解かを表示できるように変更しました

### DIFF
--- a/angular-app/src/app/judgement.service.spec.ts
+++ b/angular-app/src/app/judgement.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { JudgementService } from './judgement.service';
+
+describe('JudgementService', () => {
+  let service: JudgementService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(JudgementService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/angular-app/src/app/judgement.service.ts
+++ b/angular-app/src/app/judgement.service.ts
@@ -4,11 +4,11 @@ import { Injectable } from '@angular/core';
   providedIn: 'root',
 })
 export class JudgementService {
-  judgeAns: boolean = false;
+  isCorrectAnswer: boolean = false;
 
   constructor() {}
 
   setJudgeAns(ans: boolean) {
-    this.judgeAns = ans;
+    this.isCorrectAnswer = ans;
   }
 }

--- a/angular-app/src/app/judgement.service.ts
+++ b/angular-app/src/app/judgement.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class JudgementService {
+  judgeAns: boolean = false;
+
+  constructor() {}
+
+  setJudgeAns(ans: boolean) {
+    this.judgeAns = ans;
+  }
+}

--- a/angular-app/src/app/judgment/judgment.component.html
+++ b/angular-app/src/app/judgment/judgment.component.html
@@ -1,6 +1,6 @@
 <div class="wrapper">
   <div class="judgement">
-    <p>正解 / 不正解</p>
+    <p>{{ judgement.judgeAns ? "正解" : "不正解" }}</p>
   </div>
   <div class="flex">
     <div class="answer-content">

--- a/angular-app/src/app/judgment/judgment.component.html
+++ b/angular-app/src/app/judgment/judgment.component.html
@@ -1,6 +1,6 @@
 <div class="wrapper">
   <div class="judgement">
-    <p>{{ judgement.judgeAns ? "正解" : "不正解" }}</p>
+    <p>{{ judgement.isCorrectAnswer ? "正解" : "不正解" }}</p>
   </div>
   <div class="flex">
     <div class="answer-content">

--- a/angular-app/src/app/judgment/judgment.component.ts
+++ b/angular-app/src/app/judgment/judgment.component.ts
@@ -1,10 +1,13 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { JudgementService } from '../judgement.service';
 
 @Component({
   selector: 'app-judgment',
   templateUrl: './judgment.component.html',
-  styleUrls: ['./judgment.component.scss']
+  styleUrls: ['./judgment.component.scss'],
 })
-export class JudgmentComponent {
+export class JudgmentComponent implements OnInit {
+  constructor(public judgement: JudgementService) {}
 
+  ngOnInit(): void {}
 }

--- a/angular-app/src/app/quiz-page/quiz-page.component.html
+++ b/angular-app/src/app/quiz-page/quiz-page.component.html
@@ -8,19 +8,14 @@
     <!-- 動画テスト -->
     <iframe class="quiz-image-frame" [src]="trustUrl" allow="autoplay"></iframe>
   </div>
-
   <div class="selection">
-    <button mat-flat-button class="sl-btn" routerLink="/judge">
-      {{ quizList[1].ansOptions[0] }}
-    </button>
-    <button mat-flat-button class="sl-btn" routerLink="/judge">
-      {{ quizList[1].ansOptions[1] }}
-    </button>
-    <button mat-flat-button class="sl-btn" routerLink="/judge">
-      {{ quizList[1].ansOptions[2] }}
-    </button>
-    <button mat-flat-button class="sl-btn" routerLink="/judge">
-      {{ quizList[1].ansOptions[3] }}
+    <button
+      mat-flat-button
+      class="sl-btn"
+      *ngFor="let ansOption of quizList[1].ansOptions"
+      (click)="onSelected(ansOption)"
+    >
+      {{ ansOption }}
     </button>
   </div>
 </div>

--- a/angular-app/src/app/quiz-page/quiz-page.component.html
+++ b/angular-app/src/app/quiz-page/quiz-page.component.html
@@ -12,8 +12,8 @@
     <button
       mat-flat-button
       class="sl-btn"
-      *ngFor="let ansOption of quizList[1].ansOptions"
-      (click)="onClickAnswer(ansOption)"
+      *ngFor="let ansOption of quizList[1].ansOptions; index as i"
+      (click)="onClickAnswer(i)"
     >
       {{ ansOption }}
     </button>

--- a/angular-app/src/app/quiz-page/quiz-page.component.html
+++ b/angular-app/src/app/quiz-page/quiz-page.component.html
@@ -13,7 +13,7 @@
       mat-flat-button
       class="sl-btn"
       *ngFor="let ansOption of quizList[1].ansOptions"
-      (click)="onSelected(ansOption)"
+      (click)="onClickAnswer(ansOption)"
     >
       {{ ansOption }}
     </button>

--- a/angular-app/src/app/quiz-page/quiz-page.component.scss
+++ b/angular-app/src/app/quiz-page/quiz-page.component.scss
@@ -48,7 +48,7 @@
     }
   }
 
-  @media screen and (max-width: 450px){
+  @media screen and (max-width: 450px) {
     .selection {
       display: grid;
       grid-template-columns: 1fr;

--- a/angular-app/src/app/quiz-page/quiz-page.component.ts
+++ b/angular-app/src/app/quiz-page/quiz-page.component.ts
@@ -24,7 +24,7 @@ export class QuizPageComponent {
     );
   }
 
-  onSelected(ans: string) {
+  onClickAnswer(ans: string) {
     this.judgement.setJudgeAns(ans === this.quizList[1].ansWord);
     this.router.navigateByUrl('/judge');
   }

--- a/angular-app/src/app/quiz-page/quiz-page.component.ts
+++ b/angular-app/src/app/quiz-page/quiz-page.component.ts
@@ -1,21 +1,31 @@
 import { Component } from '@angular/core';
 import { QUIZ_LIST } from '../const';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { Router } from '@angular/router';
+import { JudgementService } from '../judgement.service';
 
 @Component({
   selector: 'app-quiz-page',
   templateUrl: './quiz-page.component.html',
-  styleUrls: ['./quiz-page.component.scss']
+  styleUrls: ['./quiz-page.component.scss'],
 })
 export class QuizPageComponent {
   quizList = QUIZ_LIST;
   trustUrl: SafeResourceUrl;
+  judgeAns: boolean = false;
 
   constructor(
     private sanitizer: DomSanitizer,
+    private router: Router,
+    private judgement: JudgementService
   ) {
     this.trustUrl = sanitizer.bypassSecurityTrustResourceUrl(
       this.quizList[1].quizImg
     );
+  }
+
+  onSelected(ans: string) {
+    this.judgement.setJudgeAns(ans === this.quizList[1].ansWord);
+    this.router.navigateByUrl('/judge');
   }
 }

--- a/angular-app/src/app/quiz-page/quiz-page.component.ts
+++ b/angular-app/src/app/quiz-page/quiz-page.component.ts
@@ -24,8 +24,8 @@ export class QuizPageComponent {
     );
   }
 
-  onClickAnswer(ans: string) {
-    this.judgement.setJudgeAns(ans === this.quizList[1].ansWord);
+  onClickAnswer(ans: number) {
+    this.judgement.setJudgeAns(ans === 0);
     this.router.navigateByUrl('/judge');
   }
 }


### PR DESCRIPTION
## Checklist for Developer

- [x] 最新のdevelopブランチをPullした。 Pulled the latest develop branch.
- [x] Pull RequestをIssueに紐付けた。 Connected with the issue.
- [x] 自分をAssignした。Assigned yourself.
- [x] レビュワーを指定した。Assigned reviewer.

## そのほかの関連するIssue / Related issues other than connected one

- #11 

## 変更内容 / Details of Changes
1. クイズ画面の選択肢から判定画面へ遷移し、正解か不正解かを表示できるようにしました。
2. その際にjugementサービスを使用して、データ間のやり取りができるようにしました。

## スクリーンショット / Screenshots
### クイズ画面(から判定画面へ)

![スクリーンショット 2023-07-03 21 08 49](https://github.com/yousukeend/alpinea/assets/40225496/7a80b9a8-cf8e-4b72-b431-3bd3adcd0988)


- こちらが`localhost:4200/quiz`クイズ画面。


### (クイズ画面から)判定画面：「正解」

<img width="1208" alt="スクリーンショット 2023-07-17 15 04 28" src="https://github.com/yousukeend/alpinea/assets/40225496/9923d274-9574-4f35-aa6f-de2bd2c448fa">

- こちらが`localhost:4200/judge`判定画面。
- クイズ画面で正しい解答を選択すると判定画面で「正解」と表示される

### (クイズ画面から)判定画面：「不正解」

<img width="1208" alt="スクリーンショット 2023-07-17 15 10 02" src="https://github.com/yousukeend/alpinea/assets/40225496/37cbb7f0-cba2-4a86-ae63-cc8f291cf384">

- クイズ画面で間違いの解答を選択すると判定画面で「不正解」と表示される

## レビューするポイント/ Points for review
- `localhost:4200/quiz`クイズ画面の４つの選択肢の中から一つ選択できる
- `localhost:4200/judge`判定画面へ遷移し、「正解」か「不正解」を表示される