### PR TITLE
判定画面でクイズの正解のデータを表示させるように変更しました

### DIFF
--- a/angular-app/src/app/judgment/judgment.component.html
+++ b/angular-app/src/app/judgment/judgment.component.html
@@ -5,14 +5,18 @@
   <div class="flex">
     <div class="answer-content">
       <div class="ans-word">
-        <p>正解の単語</p>
+        <p>{{ quizList[1].ansWord }}</p>
       </div>
       <div class="ans-exp">
-        <p>問題の解説</p>
+        <p>{{ quizList[1].ansExp }}</p>
       </div>
     </div>
     <div class="answer-img">
-      <p>ここに写真</p>
+      <iframe
+        class="quiz-image-frame"
+        [src]="trustUrl"
+        allow="autoplay"
+      ></iframe>
     </div>
   </div>
   <button mat-fab extended class="next-btn">次へ</button>

--- a/angular-app/src/app/judgment/judgment.component.scss
+++ b/angular-app/src/app/judgment/judgment.component.scss
@@ -16,7 +16,7 @@
 
   .flex {
     display: flex;
-    margin-top:4%;
+    margin-top: 4%;
     margin-left: auto;
     margin-right: auto;
     justify-content: space-between;
@@ -33,6 +33,7 @@
       .ans-word {
         background-color: #f7f7f7;
         border: 1px solid #707070;
+        padding: 5px;
         margin: 4%;
       }
 
@@ -40,6 +41,7 @@
         background-color: #f7f7f7;
         border: 1px solid #707070;
         height: 50%;
+        padding: 5px;
         margin: 4%;
       }
     }
@@ -47,6 +49,11 @@
     .answer-img {
       width: 50%;
       background-color: #f7f7f7;
+
+      .quiz-image-frame {
+        width: 100%;
+        height: 100%;
+      }
     }
   }
 

--- a/angular-app/src/app/judgment/judgment.component.ts
+++ b/angular-app/src/app/judgment/judgment.component.ts
@@ -1,10 +1,19 @@
 import { Component } from '@angular/core';
+import { QUIZ_LIST } from '../const';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-judgment',
   templateUrl: './judgment.component.html',
-  styleUrls: ['./judgment.component.scss']
+  styleUrls: ['./judgment.component.scss'],
 })
 export class JudgmentComponent {
+  quizList = QUIZ_LIST;
+  trustUrl: SafeResourceUrl;
 
+  constructor(private sanitizer: DomSanitizer) {
+    this.trustUrl = sanitizer.bypassSecurityTrustResourceUrl(
+      this.quizList[1].ansImg
+    );
+  }
 }


### PR DESCRIPTION
## Checklist for Developer

- [x] 最新のdevelopブランチをPullした。 Pulled the latest develop branch.
- [x] Pull RequestをIssueに紐付けた。 Connected with the issue.
- [x] 自分をAssignした。Assigned yourself.
- [x] レビュワーを指定した。Assigned reviewer.

## そのほかの関連するIssue / Related issues other than connected one

- #12 

## 変更内容 / Details of Changes
1. 判定画面で正解のデータを表示させるように変更しました

## スクリーンショット / Screenshots
### 判定画面

<img width="784" alt="スクリーンショット 2023-07-17 21 33 56" src="https://github.com/yousukeend/alpinea/assets/40225496/c291137a-f20d-4e10-ad90-1b1b9995b64a">


- こちらが`localhost:4200/judge`判定画面。
- 正解のワード、正解の解説、正解の写真を表示させました。

## レビューするポイント/ Points for review
- `localhost:4200/judge`判定画面で、正解のワード、正解の解説、正解の写真の表示ができる
