### PR TITLE
総合結果画面で正しく正解数と階級が表示されるように変更しました。

### DIFF
--- a/angular-app/src/app/const.ts
+++ b/angular-app/src/app/const.ts
@@ -1,5 +1,5 @@
 import { Quiz } from './types';
-
+export const NUMBER_OF_QUIZ: number = 7;
 export const QUIZ_LIST: Quiz[] = [
   {
     quizText: '後ろに見える山は何でしょう?',

--- a/angular-app/src/app/pages/quiz/quiz.component.ts
+++ b/angular-app/src/app/pages/quiz/quiz.component.ts
@@ -3,7 +3,7 @@ import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import { JudgementService } from '../../services/judgement.service';
 import { QuizService } from '../../services/quiz.service';
-import { AnsOption, Quiz } from 'src/app/types';
+import { AnsOption } from 'src/app/types';
 
 import * as _ from 'lodash';
 

--- a/angular-app/src/app/pages/result/result.component.html
+++ b/angular-app/src/app/pages/result/result.component.html
@@ -1,10 +1,10 @@
 <div class="wrapper">
   <div class="total-result">
-    <p>総合結果は、、、7問正解</p>
+    <p>総合結果は、、、{{ quizScore }}問正解</p>
   </div>
   <div class="rank">
     <div class="rank-content">
-      <p>あなたは、プロです。</p>
+      <p>あなたは、{{ userSkillLevel }}です。</p>
       <p>その優れた知識とともにスキーの発展に期待され、これを賞します。</p>
     </div>
   </div>

--- a/angular-app/src/app/pages/result/result.component.ts
+++ b/angular-app/src/app/pages/result/result.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { JudgementService } from 'src/app/services/judgement.service';
+import { JudgementService } from '../../services/judgement.service';
 
 @Component({
   selector: 'app-result',
@@ -18,9 +18,11 @@ export class ResultComponent implements OnInit {
 
   ngOnInit(): void {
     this.quizScore = this.judgementService.quizScore;
-    this.judgementService.classifySkillLevel();
-    this.userSkillLevel = this.judgementService.userSkill;
+    this.userSkillLevel = this.judgementService.classifySkillLevel(
+      this.quizScore
+    );
   }
+
   //最初からクイズをスタートさせる
   restart() {
     this.router.navigateByUrl('/');

--- a/angular-app/src/app/pages/result/result.component.ts
+++ b/angular-app/src/app/pages/result/result.component.ts
@@ -18,23 +18,11 @@ export class ResultComponent implements OnInit {
 
   ngOnInit(): void {
     this.quizScore = this.judgementService.quizScore;
-    this.classifySkillLevel(this.quizScore);
+    this.judgementService.classifySkillLevel();
+    this.userSkillLevel = this.judgementService.userSkill;
   }
   //最初からクイズをスタートさせる
   restart() {
     this.router.navigateByUrl('/');
-  }
-
-  //正解数によって階級判別をさせる
-  classifySkillLevel(score: number): void {
-    if (score >= 7) {
-      this.userSkillLevel = 'プロ';
-    } else if (score >= 5) {
-      this.userSkillLevel = '上級者';
-    } else if (score >= 3) {
-      this.userSkillLevel = '中級者';
-    } else {
-      this.userSkillLevel = '初心者';
-    }
   }
 }

--- a/angular-app/src/app/pages/result/result.component.ts
+++ b/angular-app/src/app/pages/result/result.component.ts
@@ -18,9 +18,7 @@ export class ResultComponent implements OnInit {
 
   ngOnInit(): void {
     this.quizScore = this.judgementService.quizScore;
-    this.userSkillLevel = this.judgementService.classifySkillLevel(
-      this.quizScore
-    );
+    this.userSkillLevel = this.judgementService.userSkillLevel;
   }
 
   //最初からクイズをスタートさせる

--- a/angular-app/src/app/pages/result/result.component.ts
+++ b/angular-app/src/app/pages/result/result.component.ts
@@ -1,16 +1,40 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
+import { JudgementService } from 'src/app/services/judgement.service';
 
 @Component({
   selector: 'app-result',
   templateUrl: './result.component.html',
   styleUrls: ['./result.component.scss'],
 })
-export class ResultComponent {
-  constructor(private router: Router) {}
+export class ResultComponent implements OnInit {
+  quizScore: number = 0;
+  userSkillLevel?: string;
 
+  constructor(
+    private router: Router,
+    private judgementService: JudgementService
+  ) {}
+
+  ngOnInit(): void {
+    this.quizScore = this.judgementService.totalQuizScore;
+    this.classifySkillLevel(this.quizScore);
+  }
   //最初からクイズをスタートさせる
   restart() {
     this.router.navigateByUrl('/');
+  }
+
+  //正解数に応じて階級を与える処理
+  classifySkillLevel(score: number): void {
+    if (score === 7) {
+      this.userSkillLevel = 'プロ';
+    } else if (score >= 5 && score <= 6) {
+      this.userSkillLevel = '上級者';
+    } else if (score >= 3 && score <= 4) {
+      this.userSkillLevel = '中級者';
+    } else {
+      this.userSkillLevel = '初心者';
+    }
   }
 }

--- a/angular-app/src/app/pages/result/result.component.ts
+++ b/angular-app/src/app/pages/result/result.component.ts
@@ -17,7 +17,7 @@ export class ResultComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.quizScore = this.judgementService.totalQuizScore;
+    this.quizScore = this.judgementService.quizScore;
     this.classifySkillLevel(this.quizScore);
   }
   //最初からクイズをスタートさせる
@@ -25,13 +25,13 @@ export class ResultComponent implements OnInit {
     this.router.navigateByUrl('/');
   }
 
-  //正解数に応じて階級を与える処理
+  //正解数によって階級判別をさせる
   classifySkillLevel(score: number): void {
-    if (score === 7) {
+    if (score >= 7) {
       this.userSkillLevel = 'プロ';
-    } else if (score >= 5 && score <= 6) {
+    } else if (score >= 5) {
       this.userSkillLevel = '上級者';
-    } else if (score >= 3 && score <= 4) {
+    } else if (score >= 3) {
       this.userSkillLevel = '中級者';
     } else {
       this.userSkillLevel = '初心者';

--- a/angular-app/src/app/services/judgement.service.ts
+++ b/angular-app/src/app/services/judgement.service.ts
@@ -8,6 +8,8 @@ import * as _ from 'lodash';
 export class JudgementService {
   private _isCorrectAnswer: boolean = false;
   private _quizScore: number = 0;
+  private _userSkillLevel: string = '';
+  private _userSkillScore: number = 7;
 
   constructor() {}
 
@@ -25,6 +27,19 @@ export class JudgementService {
     }
   }
 
+  //正解数によって階級判別をさせる
+  classifySkillLevel() {
+    if (this._quizScore >= this._userSkillScore) {
+      this._userSkillLevel = 'プロ';
+    } else if (this._quizScore >= this._userSkillScore - 2) {
+      this._userSkillLevel = '上級者';
+    } else if (this._quizScore >= this._userSkillScore - 4) {
+      this._userSkillLevel = '中級者';
+    } else {
+      this._userSkillLevel = '初心者';
+    }
+  }
+
   //正誤判定の取得
   get quizCorrectAnswer(): boolean {
     return this._isCorrectAnswer;
@@ -33,5 +48,10 @@ export class JudgementService {
   //正解数の取得
   get quizScore(): number {
     return this._quizScore;
+  }
+
+  //ユーザーの階級を取得
+  get userSkill(): string {
+    return this._userSkillLevel;
   }
 }

--- a/angular-app/src/app/services/judgement.service.ts
+++ b/angular-app/src/app/services/judgement.service.ts
@@ -9,7 +9,6 @@ export class JudgementService {
   private _isCorrectAnswer: boolean = false;
   private _quizScore: number = 0;
   private _userSkillLevel: string = '';
-  private _userSkillScore: number = 7;
 
   constructor() {}
 
@@ -29,11 +28,11 @@ export class JudgementService {
 
   //正解数によって階級判別をさせる
   classifySkillLevel() {
-    if (this._quizScore >= this._userSkillScore) {
+    if (this._quizScore >= 7) {
       this._userSkillLevel = 'プロ';
-    } else if (this._quizScore >= this._userSkillScore - 2) {
+    } else if (this._quizScore >= 5) {
       this._userSkillLevel = '上級者';
-    } else if (this._quizScore >= this._userSkillScore - 4) {
+    } else if (this._quizScore >= 3) {
       this._userSkillLevel = '中級者';
     } else {
       this._userSkillLevel = '初心者';

--- a/angular-app/src/app/services/judgement.service.ts
+++ b/angular-app/src/app/services/judgement.service.ts
@@ -6,32 +6,32 @@ import * as _ from 'lodash';
   providedIn: 'root',
 })
 export class JudgementService {
-  private isCorrectAnswer: boolean = false;
-  private quizScore: number = 0;
+  private _isCorrectAnswer: boolean = false;
+  private _quizScore: number = 0;
 
   constructor() {}
 
   //正誤判定の初期化処理
   initQuiz() {
-    this.isCorrectAnswer = false;
-    this.quizScore = 0;
+    this._isCorrectAnswer = false;
+    this._quizScore = 0;
   }
 
-  //正誤判定をさせる
-  setJudgeAns(ans: boolean) {
-    this.isCorrectAnswer = ans;
-    if (this.isCorrectAnswer) {
-      this.quizScore++;
+  //正誤判定の結果を格納して正解数をカウントする
+  setJudgeAns(selectedAnswer: boolean) {
+    this._isCorrectAnswer = selectedAnswer;
+    if (this._isCorrectAnswer) {
+      this._quizScore++;
     }
   }
 
   //正誤判定の取得
   get quizCorrectAnswer(): boolean {
-    return this.isCorrectAnswer;
+    return this._isCorrectAnswer;
   }
 
   //正解数の取得
-  get totalQuizScore(): number {
-    return this.quizScore;
+  get quizScore(): number {
+    return this._quizScore;
   }
 }

--- a/angular-app/src/app/services/judgement.service.ts
+++ b/angular-app/src/app/services/judgement.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { NUMBER_OF_QUIZ } from '../const';
 
 import * as _ from 'lodash';
 
@@ -8,7 +9,6 @@ import * as _ from 'lodash';
 export class JudgementService {
   private _isCorrectAnswer: boolean = false;
   private _quizScore: number = 0;
-  private _userSkillLevel: string = '';
 
   constructor() {}
 
@@ -27,15 +27,15 @@ export class JudgementService {
   }
 
   //正解数によって階級判別をさせる
-  classifySkillLevel() {
-    if (this._quizScore >= 7) {
-      this._userSkillLevel = 'プロ';
-    } else if (this._quizScore >= 5) {
-      this._userSkillLevel = '上級者';
-    } else if (this._quizScore >= 3) {
-      this._userSkillLevel = '中級者';
+  classifySkillLevel(score: number): string {
+    if (score >= NUMBER_OF_QUIZ) {
+      return 'プロ';
+    } else if (score >= NUMBER_OF_QUIZ - 2) {
+      return '上級者';
+    } else if (score >= NUMBER_OF_QUIZ - 4) {
+      return '中級者';
     } else {
-      this._userSkillLevel = '初心者';
+      return '初心者';
     }
   }
 
@@ -50,7 +50,7 @@ export class JudgementService {
   }
 
   //ユーザーの階級を取得
-  get userSkill(): string {
-    return this._userSkillLevel;
+  get userSkillLevel(): string {
+    return this.classifySkillLevel(this._quizScore);
   }
 }

--- a/angular-app/src/app/services/judgement.service.ts
+++ b/angular-app/src/app/services/judgement.service.ts
@@ -7,21 +7,31 @@ import * as _ from 'lodash';
 })
 export class JudgementService {
   private isCorrectAnswer: boolean = false;
+  private quizScore: number = 0;
 
   constructor() {}
 
   //正誤判定の初期化処理
   initQuiz() {
     this.isCorrectAnswer = false;
+    this.quizScore = 0;
   }
 
   //正誤判定をさせる
   setJudgeAns(ans: boolean) {
     this.isCorrectAnswer = ans;
+    if (this.isCorrectAnswer) {
+      this.quizScore++;
+    }
   }
 
   //正誤判定の取得
   get quizCorrectAnswer(): boolean {
     return this.isCorrectAnswer;
+  }
+
+  //正解数の取得
+  get totalQuizScore(): number {
+    return this.quizScore;
   }
 }

--- a/angular-app/src/app/services/quiz.service.ts
+++ b/angular-app/src/app/services/quiz.service.ts
@@ -9,28 +9,28 @@ import { Router } from '@angular/router';
   providedIn: 'root',
 })
 export class QuizService {
-  private randomQuizList: Quiz[] = [];
-  private randomQuizCount: number = 0;
-  private quizList = QUIZ_LIST;
+  private _randomQuizList: Quiz[] = [];
+  private _randomQuizCount: number = 0;
+  private _quizList = QUIZ_LIST;
 
   constructor(private router: Router) {}
 
   //出題する配列の初期化
   initQuiz() {
-    this.randomQuizList = [];
-    this.randomQuizCount = 0;
+    this._randomQuizList = [];
+    this._randomQuizCount = 0;
   }
 
   //クイズが開始時に一回だけ実行する
   startQuiz() {
-    this.randomQuizList = _.shuffle(this.quizList).slice(0, 7);
+    this._randomQuizList = _.shuffle(this._quizList).slice(0, 7);
   }
 
   //クイズの進行を管理
   nextQuiz() {
-    this.randomQuizCount++;
+    this._randomQuizCount++;
 
-    if (this.randomQuizCount < 7) {
+    if (this._randomQuizCount < 7) {
       this.router.navigateByUrl('/quiz');
     } else {
       this.router.navigateByUrl('/result');
@@ -39,36 +39,36 @@ export class QuizService {
 
   //問題番号を取得
   get quizCount(): number {
-    return this.randomQuizCount;
+    return this._randomQuizCount;
   }
 
   //問題文の取得
   get currentQuizText(): string {
-    return this.randomQuizList[this.randomQuizCount].quizText;
+    return this._randomQuizList[this._randomQuizCount].quizText;
   }
 
   //問題の画像または動画の取得
   get currentQuizImg(): string {
-    return this.randomQuizList[this.randomQuizCount].quizImg;
+    return this._randomQuizList[this._randomQuizCount].quizImg;
   }
 
   //問題の選択肢の取得
   get currentAnsOptions(): AnsOption[] {
-    return this.randomQuizList[this.randomQuizCount].ansOptions;
+    return this._randomQuizList[this._randomQuizCount].ansOptions;
   }
 
   //正解の単語の取得
   get answerWord(): string {
-    return this.randomQuizList[this.randomQuizCount].ansWord;
+    return this._randomQuizList[this._randomQuizCount].ansWord;
   }
 
   //正解の説明文の取得
   get answerExplanation(): string {
-    return this.randomQuizList[this.randomQuizCount].ansExp;
+    return this._randomQuizList[this._randomQuizCount].ansExp;
   }
 
   //正解の画像の取得
   get answerImage(): string {
-    return this.randomQuizList[this.randomQuizCount].ansImg;
+    return this._randomQuizList[this._randomQuizCount].ansImg;
   }
 }

--- a/angular-app/src/app/services/quiz.service.ts
+++ b/angular-app/src/app/services/quiz.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { QUIZ_LIST } from '../const';
+import { NUMBER_OF_QUIZ, QUIZ_LIST } from '../const';
 import { AnsOption, Quiz } from '../types';
 
 import * as _ from 'lodash';
@@ -23,14 +23,14 @@ export class QuizService {
 
   //クイズが開始時に一回だけ実行する
   startQuiz() {
-    this._randomQuizList = _.shuffle(this._quizList).slice(0, 7);
+    this._randomQuizList = _.shuffle(this._quizList).slice(0, NUMBER_OF_QUIZ);
   }
 
   //クイズの進行を管理
   nextQuiz() {
     this._randomQuizCount++;
 
-    if (this._randomQuizCount < 7) {
+    if (this._randomQuizCount < NUMBER_OF_QUIZ) {
       this.router.navigateByUrl('/quiz');
     } else {
       this.router.navigateByUrl('/result');


### PR DESCRIPTION
## Checklist for Developer

- [x] 最新のdevelopブランチをPullした。 Pulled the latest develop branch.
- [x] Pull RequestをIssueに紐付けた。 Connected with the issue.
- [x] 自分をAssignした。Assigned yourself.
- [x] レビュワーを指定した。Assigned reviewer.

## そのほかの関連するIssue / Related issues other than connected one

- #15 

## 変更内容 / Details of Changes
1. 総合結果画面で正解数と階級が正しく表示されるように変更しました。

## スクリーンショット / Screenshots
### 全問正解(7問)で「プロ」の階級表示

![スクリーンショット 2023-08-14 14 44 55](https://github.com/yousukeend/alpinea/assets/40225496/c62b851f-9722-43d0-8ca4-f89b5dc54ecf)

- 7問正解と表示される。
- 全て正解したので「プロ」という階級が表示される。


### 5~6問正解で「上級者」の階級表示

![スクリーンショット 2023-08-14 14 45 48](https://github.com/yousukeend/alpinea/assets/40225496/b79755ff-b7a0-43a2-a716-967f90fe909c)

- 5~6問正解すると、「上級者」という階級が表示される。

### 3~4問正解で「中級者」の階級表示

![スクリーンショット 2023-08-14 14 44 01](https://github.com/yousukeend/alpinea/assets/40225496/a021e484-5ade-4eae-975a-93d75ba6f3c2)

- 3~4問正解すると、「中級者」という階級が表示される。

### 0~2問正解で「初心者」の階級表示

![スクリーンショット 2023-08-14 14 46 27](https://github.com/yousukeend/alpinea/assets/40225496/be97cc0d-d64f-4f8b-b108-16a6bb4109f3)

- 0~2問正解すると、「初心者」という階級が表示される。

## レビューするポイント/ Points for review
- `localhost:4200/result`総合結果画面で、上記のスクショのように正しく正解数と階級が表示される